### PR TITLE
Alloc to device memory whenever possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Note to anyone who happens to stumble upon this repo
+This allocator actually does not allow ROCm to make use of the GTT, but rather, actually allocates host memory.
+From my testing on radeon 680m integrated graphics, `hipHostMalloc()` seems to perform the same as allocating directly on the device, but starts drastically slowing down when the total memory allocation is higher than what the integrated graphics have dedicated. Unfortunately, this most likely isn't the fix you wished for, but it seemed to at least work from my testing.
+
 # PyTorch Host Allocator for APUs
 
 ROCm does not take GTT into account when calculating usable VRAM on APU platforms.

--- a/gttalloc.c
+++ b/gttalloc.c
@@ -1,16 +1,31 @@
-// This code is derived from 'https://pytorch.org/docs/stable/notes/cuda.html#using-custom-memory-allocators-for-cuda'.
+// This code is derived from
+// 'https://pytorch.org/docs/stable/notes/cuda.html#using-custom-memory-allocators-for-cuda'.
 
 #define __HIP_PLATFORM_AMD__
-#include <sys/types.h>
 #include <hip/hip_runtime.h>
+#include <sys/types.h>
 // Compile with `/opt/rocm/bin/hipcc  alloc.c -o alloc.so --shared -fPIC`
 
-void* gtt_alloc(ssize_t size, int device, hipStream_t stream) {
-    void *ptr = NULL;
-    hipHostMalloc(&ptr,size,0);
-    return ptr;
+void *gtt_alloc(ssize_t size, int device, hipStream_t stream) {
+  void *ptr = NULL;
+
+  if (hipMalloc(&ptr, size) != hipSuccess) {
+    hipHostMalloc(&ptr, size, 0);
+  }
+
+  return ptr;
 }
 
-void gtt_free(void* ptr, ssize_t size, int device, hipStream_t stream) {
+void gtt_free(void *ptr, ssize_t size, int device, hipStream_t stream) {
+  hipPointerAttribute_t attr;
+
+  if (hipPointerGetAttributes(&attr, ptr) != hipSuccess) {
+    return;
+  }
+
+  if (attr.memoryType == hipMemoryTypeDevice) {
+    hipFree(ptr);
+  } else if (attr.memoryType == hipMemoryTypeHost) {
     hipHostFree(ptr);
+  }
 }


### PR DESCRIPTION
Hello, thanks for having this repository public, it's a really useful resource to have.

The proposed change allows to bind within the device's memory rather than the host, thus, massively speeding up runtime as long as host memory isn't needed. 

Previous code only relied on `hipHostMalloc`, which only uses host memory (as defined in https://rocm-developer-tools.github.io/HIP/group__Memory.html)

I've had inference speed go from 13 seconds to 4 second on a scenario where host memory usage can be avoided.

The current changes could probably use some more error handling to be really cautious, but should work find as is.

Let me know what you think

